### PR TITLE
Added experimental windows support and requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ python3 graphqlmap.py -u https://yourhostname.com/graphql -v --method POST --hea
 
 ### Dump a GraphQL schema
 
-Use `dump` to dump the GraphQL schema, this function will automaticly populate the "autocomplete" with the found fields.    
+Use `dump_new` to dump the GraphQL schema, this function will automaticly populate the "autocomplete" with the found fields.    
 [:movie_camera: Live Example](https://asciinema.org/a/14YuWoDOyCztlx7RFykILit4S)
 
 ```powershell
-GraphQLmap > dump                     
+GraphQLmap > dump_new                     
 ============= [SCHEMA] ===============
 e.g: name[Type]: arg (Type!)                   
                                                                                                

--- a/graphqlmap.py
+++ b/graphqlmap.py
@@ -1,5 +1,8 @@
 #!/usr/bin/python
-import readline
+try:
+    import readline
+except ImportError:
+    import pyreadline as readline
 
 from attacks import *
 import urllib3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+pyreadline ; sys_platform == 'win32'
+readline ; sys_platform !='win32'
+argparse
+requests


### PR DESCRIPTION
`readline` is not supported on Windows so I had to resort to using `pyreadline` instead. With the tests I did it works fine but please take note that `pyreadline` is no longer mantained, so it may break things on windows. I also added a __requirements.txt__ file and update the docs to use `dump_new` instead of `dump`