### PR TITLE
use env in shebang

### DIFF
--- a/graphqlmap.py
+++ b/graphqlmap.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
+
 try:
     import readline
 except ImportError:


### PR DESCRIPTION
This makes the tool more portable and asks for Python 3 explicitly :)

fixes #7 