### PR TITLE
JSON Error Decoder

### DIFF
--- a/graphqlmap.py
+++ b/graphqlmap.py
@@ -32,8 +32,179 @@ class GraphQLmap(object):
         print(" " * 30, end='')
         print(f"\033[1mAuthor\033[0m: {self.author} \033[1mVersion\033[0m: {self.version} ")
         self.args = args_graphql
-        self.url = args_graphql.url
-        self.method = args_graphql.method
+        self.url = args_graphql
+
+        if args_graphql.method != None:
+        	self.method = args_graphql.method
+        else:
+        	self.method = "POST"
+
+        self.headers = None if not args_graphql.headers else json.loads(args_graphql.headers)
+        self.use_json = True if args_graphql.use_json else False
+
+        while True:
+            query = input("GraphQLmap > ")
+            cmdlist.append(query)
+            if query == "exit" or query == "q":
+                exit()
+
+            elif query == "help":
+                display_help()
+
+            elif query == "debug":
+                display_types(self.url, self.method, self.headers, self.use_json)
+
+            elif query == "dump_new":
+                dump_schema(self.url, self.method, 15, self.headers, self.use_json)
+
+            elif query == "dump_old":
+                dump_schema(self.url, self.method, 14, self.headers, self.use_json)
+
+            elif query == "nosqli":
+                blind_nosql(self.url, self.method, self.headers, self.use_json)
+
+            elif query == "postgresqli":
+                blind_postgresql(self.url, self.method, self.headers, self.use_json)
+
+            elif query == "mysqli":
+                blind_mysql(self.url, self.method, self.headers, self.use_json)
+
+            elif query == "mssqli":
+                blind_mssql(self.url, self.method, self.headers, self.use_json)
+
+            else:
+                exec_advanced(args_graphql.url, self.method, query, self.headers, self.use_json)
+
+
+if __name__ == "__main__":
+    readline.set_completer(auto_completer)
+    readline.parse_and_bind("tab: complete")
+    args = parse_args()
+    GraphQLmap(args)
+#!/usr/bin/env python3
+
+try:
+    import readline
+except ImportError:
+    import pyreadline as readline
+
+from attacks import *
+import urllib3
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+
+class GraphQLmap(object):
+    author = "@pentest_swissky"
+    version = "1.0"
+    endpoint = "graphql"
+    method = "POST"
+    args = None
+    url = None
+    headers = None
+    use_json = False
+
+    def __init__(self, args_graphql):
+        print("   _____                 _      ____  _                            ")
+        print("  / ____|               | |    / __ \| |                           ")
+        print(" | |  __ _ __ __ _ _ __ | |__ | |  | | |     _ __ ___   __ _ _ __  ")
+        print(" | | |_ | '__/ _` | '_ \| '_ \| |  | | |    | '_ ` _ \ / _` | '_ \ ")
+        print(" | |__| | | | (_| | |_) | | | | |__| | |____| | | | | | (_| | |_) |")
+        print("  \_____|_|  \__,_| .__/|_| |_|\___\_\______|_| |_| |_|\__,_| .__/ ")
+        print("                  | |                                       | |    ")
+        print("                  |_|                                       |_|    ")
+        print(" " * 30, end='')
+        print(f"\033[1mAuthor\033[0m: {self.author} \033[1mVersion\033[0m: {self.version} ")
+        self.args = args_graphql
+        self.url = args_graphql
+
+        if args_graphql.method != None:
+        	self.method = args_graphql.method
+        else:
+        	self.method = "POST"
+
+        self.headers = None if not args_graphql.headers else json.loads(args_graphql.headers)
+        self.use_json = True if args_graphql.use_json else False
+
+        while True:
+            query = input("GraphQLmap > ")
+            cmdlist.append(query)
+            if query == "exit" or query == "q":
+                exit()
+
+            elif query == "help":
+                display_help()
+
+            elif query == "debug":
+                display_types(self.url, self.method, self.headers, self.use_json)
+
+            elif query == "dump_new":
+                dump_schema(self.url, self.method, 15, self.headers, self.use_json)
+
+            elif query == "dump_old":
+                dump_schema(self.url, self.method, 14, self.headers, self.use_json)
+
+            elif query == "nosqli":
+                blind_nosql(self.url, self.method, self.headers, self.use_json)
+
+            elif query == "postgresqli":
+                blind_postgresql(self.url, self.method, self.headers, self.use_json)
+
+            elif query == "mysqli":
+                blind_mysql(self.url, self.method, self.headers, self.use_json)
+
+            elif query == "mssqli":
+                blind_mssql(self.url, self.method, self.headers, self.use_json)
+
+            else:
+                exec_advanced(args_graphql.url, self.method, query, self.headers, self.use_json)
+
+
+if __name__ == "__main__":
+    readline.set_completer(auto_completer)
+    readline.parse_and_bind("tab: complete")
+    args = parse_args()
+    GraphQLmap(args)
+#!/usr/bin/env python3
+
+try:
+    import readline
+except ImportError:
+    import pyreadline as readline
+
+from attacks import *
+import urllib3
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+
+class GraphQLmap(object):
+    author = "@pentest_swissky"
+    version = "1.0"
+    endpoint = "graphql"
+    method = "POST"
+    args = None
+    url = None
+    headers = None
+    use_json = False
+
+    def __init__(self, args_graphql):
+        print("   _____                 _      ____  _                            ")
+        print("  / ____|               | |    / __ \| |                           ")
+        print(" | |  __ _ __ __ _ _ __ | |__ | |  | | |     _ __ ___   __ _ _ __  ")
+        print(" | | |_ | '__/ _` | '_ \| '_ \| |  | | |    | '_ ` _ \ / _` | '_ \ ")
+        print(" | |__| | | | (_| | |_) | | | | |__| | |____| | | | | | (_| | |_) |")
+        print("  \_____|_|  \__,_| .__/|_| |_|\___\_\______|_| |_| |_|\__,_| .__/ ")
+        print("                  | |                                       | |    ")
+        print("                  |_|                                       |_|    ")
+        print(" " * 30, end='')
+        print(f"\033[1mAuthor\033[0m: {self.author} \033[1mVersion\033[0m: {self.version} ")
+        self.args = args_graphql
+        self.url = args_graphql
+
+        if args_graphql.method != None:
+        	self.method = args_graphql.method
+        else:
+        	self.method = "POST"
+
         self.headers = None if not args_graphql.headers else json.loads(args_graphql.headers)
         self.use_json = True if args_graphql.use_json else False
 

--- a/utils.py
+++ b/utils.py
@@ -44,7 +44,7 @@ def parse_args():
     parser.add_argument('-u', action='store', dest='url', help="URL to query : example.com/graphql?query={}")
     parser.add_argument('-v', action='store', dest='verbosity', help="Enable verbosity", nargs='?', const=True)
     parser.add_argument('--method', action='store', dest='method',
-                        help="HTTP Method to use interact with /graphql endpoint", nargs='?', const=True, default="GET")
+                        help="HTTP Method to use interact with /graphql endpoint", nargs='?', const=True)
     parser.add_argument('--headers', action='store', dest='headers', help="HTTP Headers sent to /graphql endpoint",
                         nargs='?', const=True, type=str)
     parser.add_argument('--json', action='store', dest='use_json', help="Use JSON encoding, implies POST", nargs='?', const=True, type=bool)


### PR DESCRIPTION
python graphqlmap.py -u http://xxxxxxxx/24e52a10fc/graphql -v 

query:
``` 
fragment FullType on __Type {
  kind
  name
  fields(includeDeprecated: true) {
    name
    args {
      ...InputValue
    }
    type {
      ...TypeRef
    }
    isDeprecated
    deprecationReason
  }
  inputFields {
    ...InputValue
  }
  interfaces {
    ...TypeRef
  }
  enumValues(includeDeprecated: true) {
    name
    isDeprecated
    deprecationReason
  }
  possibleTypes {
    ...TypeRef
  }
}
fragment InputValue on __InputValue {
  name
  type {
    ...TypeRef
  }
  defaultValue
}
fragment TypeRef on __Type {
  kind
  name
  ofType {
    kind
    name
    ofType {
      kind
      name
      ofType {
        kind
        name
        ofType {
          kind
          name
          ofType {
            kind
            name
            ofType {
              kind
              name
              ofType {
                kind
                name
              }
            }
          }
        }
      }
    }
  }
}
query IntrospectionQuery {
  __schema {
    queryType {
      name
    }
    mutationType {
      name
    }
    types {
      ...FullType
    }
    directives {
      name
      locations
      args {
        ...InputValue
      }
    }
  }
}
```

I would like to propose this modification, considering that by default I define GET as the standard method, but it mostly breaks into very large queries.

I set POST as the default and performed the verification before making the requests.