### PR TITLE
Correcting "NameError: nome 'time' is not defined"

### DIFF
--- a/attacks.py
+++ b/attacks.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 from utils import *
+import time
 
 
 def display_types(URL, method, headers, use_json):


### PR DESCRIPTION
When using GraphQLmap and attempting to use the `postgresqli` feature, you will receive a "NameError: name 'time' is not defined" which occurs because `time` was not imported.

```
$ python3 graphqlmap.py -u https://site/graphql -v --json
   _____                 _      ____  _                            
  / ____|               | |    / __ \| |                           
 | |  __ _ __ __ _ _ __ | |__ | |  | | |     _ __ ___   __ _ _ __  
 | | |_ | '__/ _` | '_ \| '_ \| |  | | |    | '_ ` _ \ / _` | '_ \ 
 | |__| | | | (_| | |_) | | | | |__| | |____| | | | | | (_| | |_) |
  \_____|_|  \__,_| .__/|_| |_|\___\_\______|_| |_| |_|\__,_| .__/ 
                  | |                                       | |    
                  |_|                                       |_|    
                              Author: @pentest_swissky Version: 1.0 
GraphQLmap > postgresqli
Query > select version()
Traceback (most recent call last):
  File "/home/kali/GraphQLmap/graphqlmap.py", line 79, in <module>
    GraphQLmap(args)
  File "/home/kali/GraphQLmap/graphqlmap.py", line 63, in __init__
    blind_postgresql(self.url, self.method, self.headers, self.use_json)
  File "/home/kali/GraphQLmap/attacks.py", line 137, in blind_postgresql
    print("\033[92m[+] Started at: {}\033[0m".format(time.asctime(time.localtime(time.time()))))
NameError: name 'time' is not defined
```

This pull request resolves the issue by adding the `time` import.