### PR TITLE
Remove argparse

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 pyreadline ; sys_platform == 'win32'
 readline ; sys_platform !='win32'
-argparse
 requests


### PR DESCRIPTION
`argparse` is a [default module](https://docs.python.org/3/library/argparse.html).