### PR TITLE
Switch to depending on gnureadline instead

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pyreadline ; sys_platform == 'win32'
-readline ; sys_platform !='win32'
+gnureadline ; sys_platform !='win32'
 requests


### PR DESCRIPTION
The old readline package is only relevant up to Python<=3.3 and is now deprecated.

From https://pypi.org/project/readline/:
> 6.2.4.2 (2022-06-24)
> THIS PACKAGE IS DEPRECATED! USE gnureadline INSTEAD!

The `gnureadline` package works/should work as a drop-in replacement.

Fixes installation errors such as:
```
      clang -bundle -undefined dynamic_lookup -Wl,-headerpad,0x1000 build/temp.macosx-10.9-universal2-cpython-39/Modules/3.x/readline.o readline/libreadline.a readline/libhistory.a -lncurses -o build/lib.macosx-10.9-universal2-cpython-39/readline.cpython-39-darwin.so -arch i386 -arch x86_64
      clang: error: no such file or directory: 'readline/libreadline.a'
      clang: error: no such file or directory: 'readline/libhistory.a'
      error: command '/usr/bin/clang' failed with exit code 1
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for readline
Failed to build readline
ERROR: Could not build wheels for readline, which is required to install pyproject.toml-based projects
```